### PR TITLE
docs: add decompilation survey notes for Xbox Cache Beta

### DIFF
--- a/notes/decompilation_survey_notes.md
+++ b/notes/decompilation_survey_notes.md
@@ -1,0 +1,70 @@
+# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes
+
+This document captures the reverse engineering findings, mapped functions, database updates, and subsystem details discovered during the survey of the Halo: Combat Evolved Xbox Cache Beta binary (`cachebeta.xbe`).
+
+---
+
+## 1. Mapped Execution Path
+
+We successfully traced the game's startup and initialization sequence from the Windows/Xbox loader to the main game loop:
+
+```mermaid
+graph TD
+    A[mainCRTStartup 0x15cc9] -->|CreateThread| B[mainXapiStartup 0x15c5a]
+    B -->|Call __cdecl| C[main_entry 0x56960]
+    C -->|D3D probe| D[rasterizer_preinitialize 0x7f140]
+    C -->|Alloc pools| E[physical_memory_allocate 0x32e40]
+    C -->|Init subsystems| F[shell_initialize 0x56a20]
+    F -->|RNG & Geosphere| G[random_math_initialize 0xb5460]
+    F -->|Alloc lookup tables| H[periodic_functions_initialize 0x174350]
+    F -->|Direct3D & shaders| I[rasterizer_device_initialize 0x625b0]
+    F -->|Input init| J[input_initialize 0xe3be0]
+    F -->|Sound manager| K[sound_manager_initialize 0x267a0]
+    C -->|Enter loop| L[main_loop 0xbd420]
+    C -->|Shutdown/Cleanup| M[shell_dispose 0x569b0]
+```
+
+---
+
+## 2. Function Inventory & Database Updates
+
+The following functions have been identified and renamed in the active IDA Pro database (`cachebeta.xbe.i64`):
+
+| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
+| :--- | :--- | :--- | :--- |
+| **`0x15cc9`** | `mainCRTStartup` | *Unchanged* | CRT Entry point; initializes TLS index, spawns main Xapi thread. |
+| **`0x15c5a`** | `mainXapiStartup` | *Unchanged* | Process & thread initialization, runtime initialization (`cinit`/`rtinit`), enters main game flow. |
+| **`0x56960`** | `sub_56960` | `main_entry` | Game main entry point. Coordinates pre-initialization, subsystem boot, and loop. |
+| **`0x7f140`** | `sub_7F140` | `rasterizer_preinitialize` | Creates temporary Direct3D 8 HAL device (640x480) to query hardware capabilities. |
+| **`0x32e40`** | `sub_32E40` | `physical_memory_allocate` | Allocates the primary contiguous memory blocks via `MmAllocateContiguousMemoryEx`. |
+| **`0x56a20`** | `sub_56A20` | `shell_initialize` | System initialization sequence (RNG, periodic tables, D3D, Input, Audio). |
+| **`0xbd420`** | `sub_BD420` | `main_loop` | Main game loop running ticks, level loads, game state sync, and frame rendering. |
+| **`0x569b0`** | `sub_569B0` | `shell_dispose` | Disposes tags, audio, input, and memory resources on exit. |
+| **`0xb5460`** | `sub_B5460` | `random_math_initialize` | Sets random seed using entropy sources and triggers geosphere generation. |
+| **`0xb8840`** | `sub_B8840` | `random_direction_geosphere_generate` | Generates geodesic dome/sphere coordinates dynamically (different from retail PC). |
+| **`0x174350`** | `sub_174350` | `periodic_functions_initialize` | Allocates and fills periodic & transition tables. |
+| **`0x174090`** | `sub_174090` | `periodic_function_generate` | Generates 12 specific periodic lookup table patterns. |
+| **`0x173c10`** | `sub_173C10` | `transition_function_generate` | Generates 6 specific transition lookup table patterns. |
+
+---
+
+## 3. Subsystem Insights
+
+### Dynamic Geosphere Generation (`0xb8840`)
+In the PC retail version of Halo, the unit geosphere vectors used to query random direction angles are loaded from a compiled game tag block (`random_direction_geosphere` tag type `0x10`).
+In the Xbox Cache Beta build, we discovered that **`random_direction_geosphere_generate`** builds this mesh procedurally on boot:
+* It allocates a vertex buffer for `8 * a1 * a1` elements (`a1 = 16` -> 2048 elements).
+* It loops through subdivisions using a userpurge helper (`sub_B8680`) and stores the resulting coordinate floats in a global pointer.
+* This dynamic generation completely removes the dependency on the pre-built geosphere tag at startup.
+
+### Periodic & Transition Tables (`0x174350`)
+The animation, particle, and FX systems rely on pre-computed waves and ramps:
+* **Periodic Tables:** Allocates 12 lookup buffers of `0x400` bytes (total 1024 float/byte entries each) for shapes like cosine, triangle waves, stutter harmonics, and Gaussian curves.
+* **Transition Tables:** Allocates 6 lookup buffers of `0x400` bytes mapping transition functions.
+
+---
+
+## 4. Next Tasks / Open Areas
+- [ ] Map the network state synchronization packet handlers under `main_loop`.
+- [ ] Decompile the Direct3D device creation (`sub_7FA10`) render state details.
+- [ ] Match structure block / tag parsing logic inside the cache loader.

--- a/notes/decompilation_survey_notes_part2.md
+++ b/notes/decompilation_survey_notes_part2.md
@@ -1,0 +1,95 @@
+# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 2)
+
+This document captures the second phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the network message loops, asynchronous file system I/O, and Xbox-specific NV2A Direct3D render states.
+
+---
+
+## 1. Mapped Execution Path
+
+The diagram below details the execution path of the network tick loop and background asynchronous I/O threads:
+
+```mermaid
+graph TD
+    ML[main_loop 0xbd420] -->|If Client| CSF[network_game_client_start_frame 0x9eda0]
+    ML -->|If Server| SSF[network_game_server_start_frame 0x9d7b0]
+    ML -->|Frame End| CEF[network_game_client_end_frame 0x9eae0]
+    
+    CSF -->|Dispatch State 3| NCM[network_client_process_message 0x17e710]
+    NCM -->|Switch Type| MSG[16 Server-to-Client Message Handlers]
+    SSF -->|New Connection| SC[sub_9C780]
+    
+    subgraph Async IO Threads
+        T1[map_cache_io_worker_thread_1 0x33af0] -->|De-queue & Read| AR[XapiReadFileAsync 0x153b3]
+        T2[map_cache_decompression_worker_thread_2 0x34cf0] -->|Decompress| DC[Cache Sectors]
+    end
+```
+
+---
+
+## 2. Function Inventory & Database Updates
+
+The following functions have been identified, renamed, and commented in the active IDA Pro database (`cachebeta.xbe.i64`):
+
+| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
+| :--- | :--- | :--- | :--- |
+| **`0x9eda0`** | `sub_9EDA0` | `network_game_client_start_frame` | Client start frame; manages connection state updates and processes packets. |
+| **`0x9d7b0`** | `sub_9D7B0` | `network_game_server_start_frame` | Server start frame; monitors link status and accepts incoming client joins. |
+| **`0x9eae0`** | `sub_9EAE0` | `network_game_client_end_frame` | Client end frame; handles packet finalization and transmit queues. |
+| **`0x17e710`** | `sub_17E710` | `network_client_process_message` | Client-side network message dispatcher; parses packet headers. |
+| **`0x17e200`** | `sub_17E200` | `handle_message_server_game_advertise` | Client handler for incoming server advertise messages (Type 2). |
+| **`0x17e1a0`** | `sub_17E1A0` | `handle_message_server_pong` | Client handler for ping response messages (Type 3). |
+| **`0x17e0f0`** | `sub_17E0F0` | `handle_message_server_machine_accepted` | Client handler for join machine accepted messages (Type 4). |
+| **`0x17e040`** | `sub_17E040` | `handle_message_server_machine_rejected` | Client handler for join machine rejected messages (Type 5). |
+| **`0x17e4e0`** | `sub_17E4E0` | `handle_message_server_game_settings_update` | Client handler for settings synchronization messages (Type 6). |
+| **`0x17dfa0`** | `sub_17DFA0` | `handle_message_server_pregame_countdown` | Client handler for pregame start countdown status (Type 7). |
+| **`0x17e5b0`** | `sub_17E5B0` | `handle_message_server_begin_game` | Client handler for server starting gameplay transition (Type 8). |
+| **`0x17ddd0`** | `sub_17DDD0` | `handle_message_server_graceful_game_exit_pregame` | Client handler for pregame graceful disconnect (Type 9). |
+| **`0x17df10`** | `sub_17DF10` | `handle_message_server_pregame_keep_alive` | Client handler for pregame keepalive ping (Type 10). |
+| **`0x17de80`** | `sub_17DE80` | `handle_message_server_postgame_keep_alive` | Client handler for postgame keepalive ping (Type 11). |
+| **`0x17e410`** | `sub_17E410` | `handle_message_server_game_update` | Client handler for in-game state sync packet payload (Type 20). |
+| **`0x17e350`** | `sub_17E350` | `handle_message_server_add_player_ingame` | Client handler for dynamic player join announcements (Type 21). |
+| **`0x17e290`** | `sub_17E290` | `handle_message_server_remove_player_ingame` | Client handler for dynamic player quit announcements (Type 22). |
+| **`0x17dd40`** | `sub_17DD40` | `handle_message_server_game_over` | Client handler for match game-over announcements (Type 23). |
+| **`0x17e660`** | `sub_17E660` | `handle_message_server_switch_to_pregame` | Client handler for postgame transition back to lobby (Type 30). |
+| **`0x17dc80`** | `sub_17DC80` | `handle_message_server_graceful_game_exit_postgame` | Client handler for postgame lobby exit/cleanup status (Type 31). |
+| **`0x14640`** | `sub_14640` | `XapiCreateFile` | standard wrapper translating parameters to NT Native `NtCreateFile`. |
+| **`0x15455`** | `sub_15455` | `XapiGetFileSize` | Wrapper mapping standard Win32 file size query logic. |
+| **`0x15375`** | `sub_15375` | `XapiGetFileSizeEx` | Calls `NtQueryInformationFile` for standard size attributes. |
+| **`0x150a4`** | `sub_150A4` | `XapiSetFilePointer` | Calls `NtSetInformationFile` for current file pointer update. |
+| **`0x15020`** | `sub_15020` | `XapiSetEndOfFile` | Calls `NtSetInformationFile` to truncate/adjust file size. |
+| **`0x153b3`** | `sub_153B3` | `XapiReadFileAsync` | Asynchronous file read callback wrapper calling `NtReadFile`. |
+| **`0x15404`** | `sub_15404` | `XapiWriteFileAsync` | Asynchronous file write callback wrapper calling `NtWriteFile`. |
+| **`0x331d0`** | `sub_331D0` | `XapiExecuteAsyncIo` | Standard async I/O loop worker coordinating pending APC queues. |
+| **`0x33af0`** | `StartAddress` | `map_cache_io_worker_thread_1` | Worker thread prioritizing and submitting file read requests. |
+| **`0x34cf0`** | `sub_34CF0` | `map_cache_decompression_worker_thread_2` | Worker thread decompressing streamed map sectors in background. |
+| **`0x625b0`** | `sub_625B0` | `rasterizer_device_initialize` | Sets up memory contexts and starts Direct3D hardware device. |
+| **`0x7fa10`** | `sub_7FA10` | `rasterizer_device_initialize_internal` | Allocates textures, sets shader constant mode, and configures GPU render states. |
+
+---
+
+## 3. Subsystem Insights
+
+### Dynamic Geosphere Generation (`0xb8840`)
+In the PC retail version of Halo, the unit geosphere vectors used to query random direction angles are loaded from a compiled game tag block (`random_direction_geosphere` tag type `0x10`).
+In the Xbox Cache Beta build, we discovered that **`random_direction_geosphere_generate`** builds this mesh procedurally on boot:
+* It allocates a vertex buffer for `8 * a1 * a1` elements (`a1 = 16` -> 2048 elements).
+* It loops through subdivisions using a userpurge helper (`sub_B8680`) and stores the resulting coordinate floats in a global pointer.
+* This dynamic generation completely removes the dependency on the pre-built geosphere tag at startup.
+
+### Periodic & Transition Tables (`0x174350`)
+The animation, particle, and FX systems rely on pre-computed waves and ramps:
+* **Periodic Tables:** Allocates 12 lookup buffers of `0x400` bytes (total 1024 float/byte entries each) for shapes like cosine, triangle waves, stutter harmonics, and Gaussian curves.
+* **Transition Tables:** Allocates 6 lookup buffers of `0x400` bytes mapping transition functions.
+
+---
+
+## 4. Xbox NV2A D3D Render States
+
+During D3D device setup in **`rasterizer_device_initialize_internal` (`0x7fa10`)**, we mapped the following Xbox-specific registers and render states:
+
+* **Alpha Blend Enable (`0x40304` / `820`):** Set to 1 to enable alpha blending.
+* **Alpha Blend Source/Destination (`0x40344` / `836`):** Standard blending multipliers.
+* **Alpha Blend Op (`0x40348` / `840`):** Set to `0x8006` (`D3DBLENDOP_ADD`).
+* **Depth/Z-Comparison Function (`0x40354` / `852`):** Set to `515` (`0x203` -> `D3DCMP_LESSEQUAL`).
+* **Logical Op (`0x4035c` / `860`):** Direct GPU logical raster operations.
+* **Soft Display & Flicker Filters:** Xbox TV output encoders configured to use flicker filtering.

--- a/notes/decompilation_survey_notes_part3.md
+++ b/notes/decompilation_survey_notes_part3.md
@@ -1,0 +1,57 @@
+# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 3)
+
+This document captures the third phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the Object Table Manager subsystem, entity lifecycle transitions (creation, deletion, relevance testing), and periodic garbage collection ticks.
+
+---
+
+## 1. Mapped Execution Path
+
+The diagram below details the interaction flow between player tick updates, relevance determination, and the garbage collection of dead/unreachable game entities:
+
+```mermaid
+graph TD
+    ML[main_loop 0xbd420] -->|Every Tick| OU[objects_update 0x145170]
+    ML -->|Every Tick| GC[objects_garbage_collect_tick 0x144B00]
+    
+    GC -->|Actor Update Evaluator| AU[actor_update_evaluator 0x144290]
+    GC -->|If Out of Bounds / Dead| OD[object_delete_internal 0x140BC0]
+    
+    OU -->|Player Relevance Loop| RL[objects_update_relevance_loop 0x1451B0]
+    RL -->|Iterate Players| PI[player_iterator 0x13AA00]
+    RL -->|Update Relevance| UR[object_update_relevance 0x144CF0]
+    UR -->|Relevance Helper| IR[object_is_player_relevant 0x145140]
+```
+
+---
+
+## 2. Function Inventory & Database Updates
+
+The following functions have been identified, renamed, and commented in the active IDA Pro database (`cachebeta.xbe.i64`):
+
+| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
+| :--- | :--- | :--- | :--- |
+| **`0x13AA00`** | `sub_13AA00` | `player_iterator` | Iterator helper that traverses active player indices inside player tables. |
+| **`0x140BC0`** | `sub_140BC0` | `object_delete_internal` | Main function that tears down unit references, cleans attachments, and deletes objects. |
+| **`0x143C00`** | `sub_143C00` | `object_new` | Instantiates new objects and registers headers inside the global data tables. |
+| **`0x144290`** | `sub_144290` | `actor_update_evaluator` | Handles per-tick evaluations of player-to-actor visibility and updates. |
+| **`0x144B00`** | `sub_144B00` | `objects_garbage_collect_tick` | Ticks periodic dynamic entity cleanup loops and monitors overall memory pressure. |
+| **`0x144CF0`** | `sub_144CF0` | `object_update_relevance` | Inner relevance routine evaluating distances, visibility, and state of players. |
+| **`0x145140`** | `sub_145140` | `object_is_player_relevant` | Checks if a given player is near or relevant (e.g. within 5.0 units distance). |
+| **`0x1451B0`** | `sub_1451B0` | `objects_update_relevance_loop` | Outer relevance loop checking player relationship tables for updates. |
+| **`0x1453A0`** | `sub_1453A0` | `objects_update_visibility_loop` | Checks player-to-player visibility changes and updates player relationship indices. |
+
+---
+
+## 3. Subsystem Insights
+
+### Dynamic Entity Garbage Collection (`0x144B00`)
+The game engine maintains system stability by performing a periodic garbage collection sweep of objects. Under `objects_garbage_collect_tick`:
+* It iterates through active actors/units using `player_iterator` structures.
+* It checks if entities are dead or marked for deletion (using unit shield/body vitality checks or out-of-bounds map checks).
+* If an entity is marked for deletion or fails active presence checks, it calls `object_delete_internal` to clean up parent/child attachments and release its slots from the `player_data` array.
+
+### Player Relevance & Update Rates (`0x1451B0` & `0x144CF0`)
+The engine dynamically adjusts update rates based on spatial relationship and PVS (Potentially Visible Set) state:
+* Local players and entities in the same PVS sector are marked as high relevance and update every tick.
+* Remote/distant players are checked via `object_is_player_relevant` against a distance threshold (e.g., `5.0` units).
+* If a remote player is too far away or outside the active PVS, updates are throttled to save bandwidth and FPU computation time.

--- a/notes/decompilation_survey_notes_part3.md
+++ b/notes/decompilation_survey_notes_part3.md
@@ -1,11 +1,12 @@
 # Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 3)
 
-This document captures the third phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the Object Table Manager subsystem, entity lifecycle transitions (creation, deletion, relevance testing), and periodic garbage collection ticks.
+This document captures the third phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the Object Table Manager subsystem, Xbox player profiles (async disk I/O, signing), and multiplayer biped configuration paths.
 
 ---
 
-## 1. Mapped Execution Path
+## 1. Mapped Execution Paths
 
+### Object Update & Garbage Collection Flow
 The diagram below details the interaction flow between player tick updates, relevance determination, and the garbage collection of dead/unreachable game entities:
 
 ```mermaid
@@ -22,6 +23,24 @@ graph TD
     UR -->|Relevance Helper| IR[object_is_player_relevant 0x145140]
 ```
 
+### Profile Saving & Biped Selection Flow
+The diagram below illustrates how player character model updates are written to the local filesystem (`z:\last_solo.txt`) and asynchronously signed and saved to the Xbox hard disk:
+
+```mermaid
+graph TD
+    ML[main_loop 0xbd420] -->|Menu Loop| MM[main_menu_update 0xbd2d0]
+    MM -->|Startup Load| PL[player_load_last_solo_biped_model 0xbc020]
+    PL -->|Read String| PF[player_biped_model_from_string 0xbbb90]
+    PL -->|Copy Cache| PN[player_set_biped_model_name 0xbbdc0]
+    
+    MM -->|Apply Settings| PS[player_save_last_solo_biped_model 0xbbd70]
+    PS -->|Write Cache| PF
+    
+    MM -->|Queue Profile Save| PA[player_profile_save_async 0x30ce0]
+    PA -->|Spawn Thread| PW[player_profile_save_thread_worker 0x30bc0]
+    PW -->|Xbox Signature| XS[XCalculateSignatureBegin API]
+```
+
 ---
 
 ## 2. Function Inventory & Database Updates
@@ -30,6 +49,8 @@ The following functions have been identified, renamed, and commented in the acti
 
 | Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
 | :--- | :--- | :--- | :--- |
+| **`0x30BC0`** | `sub_30BC0` | `player_profile_save_thread_worker` | Async thread worker that calculates savegame signatures and writes profiles to disk. |
+| **`0x30CE0`** | `sub_30CE0` | `player_profile_save_async` | Initiates asynchronous player profile saves using Xbox worker threads. |
 | **`0x13AA00`** | `sub_13AA00` | `player_iterator` | Iterator helper that traverses active player indices inside player tables. |
 | **`0x140BC0`** | `sub_140BC0` | `object_delete_internal` | Main function that tears down unit references, cleans attachments, and deletes objects. |
 | **`0x143C00`** | `sub_143C00` | `object_new` | Instantiates new objects and registers headers inside the global data tables. |
@@ -39,6 +60,11 @@ The following functions have been identified, renamed, and commented in the acti
 | **`0x145140`** | `sub_145140` | `object_is_player_relevant` | Checks if a given player is near or relevant (e.g. within 5.0 units distance). |
 | **`0x1451B0`** | `sub_1451B0` | `objects_update_relevance_loop` | Outer relevance loop checking player relationship tables for updates. |
 | **`0x1453A0`** | `sub_1453A0` | `objects_update_visibility_loop` | Checks player-to-player visibility changes and updates player relationship indices. |
+| **`0xBBB90`** | `sub_BBB90` | `player_biped_model_from_string` | Parses string representations of multiplayer characters (e.g. `"a10"`, `"b30"`) to index `0-9`. |
+| **`0xBBD70`** | `sub_BBD70` | `player_save_last_solo_biped_model` | Saves the chosen player model name string to the Xbox cache file `z:\last_solo.txt`. |
+| **`0xBBDC0`** | `sub_BBDC0` | `player_set_biped_model_name` | Copies the chosen biped model string name to the global memory buffer. |
+| **`0xBC020`** | `sub_BC020` | `player_load_last_solo_biped_model` | Reads `z:\last_solo.txt` at boot to restore the last configured character model. |
+| **`0xBD2D0`** | `sub_BD2D0` | `main_menu_update` | Main loop sub-helper executing menu screens, title music, and biped changes. |
 
 ---
 
@@ -55,3 +81,9 @@ The engine dynamically adjusts update rates based on spatial relationship and PV
 * Local players and entities in the same PVS sector are marked as high relevance and update every tick.
 * Remote/distant players are checked via `object_is_player_relevant` against a distance threshold (e.g., `5.0` units).
 * If a remote player is too far away or outside the active PVS, updates are throttled to save bandwidth and FPU computation time.
+
+### Xbox Biped Cache & Profiles (`0xBBB90` & `0xBC020`)
+Xbox Halo manages local client customization profiles differently from standard PC builds:
+* **Model Choices**: The biped/model indices are mapped from strings: `"a10"`, `"a30"`, `"a50"`, `"b30"`, `"b40"`, `"c10"`, `"c20"`, `"c40"`, `"d20"`, `"d40"`.
+* **FS Cache**: It saves the last chosen biped model choice directly to `z:\last_solo.txt`. The `Z:` drive represents the Xbox DVD cache utility partition, allowing fast startup configuration reads without mounting large content paths.
+* **Async Profiles**: When saving player settings, the engine executes `player_profile_save_async` to spawn a worker thread (`player_profile_save_thread_worker`). This worker thread uses the Xbox XDK `XCalculateSignatureBegin` API family to append tamper-proof SHA1 signatures to savegames before flushing them to the hard disk.

--- a/notes/decompilation_survey_notes_part4.md
+++ b/notes/decompilation_survey_notes_part4.md
@@ -1,0 +1,63 @@
+# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 4)
+
+This document captures the fourth phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the DirectSound audio engine layer, Xbox-specific hardware voices, environmental reverb (I3DL2), and kernel-level stream status tracking.
+
+---
+
+## 1. Mapped Execution Path
+
+The diagram below details the DirectSound initialization, stream configuration, and channel resolution pipelines:
+
+```mermaid
+graph TD
+    SM[sound_manager_initialize 0x267a0] -->|Driver Initialize| SI[sound_dsound_initialize 0x29f10]
+    SI -->|Listener Setup| SL[sound_dsound_set_listener_properties 0x28bd0]
+    SI -->|Create streams| SC[sound_dsound_stream_create 0x29cb0]
+    
+    SC -->|Configure channels| SP[sound_dsound_stream_set_properties 0x297b0]
+    SP -->|Update 3D| S3[sound_dsound_stream_update_3d 0x29a40]
+    SP -->|Update I3DL2 Reverb| SR[sound_dsound_stream_update_i3dl2 0x296d0]
+    
+    PLAY[Sound Playback Ticks] -->|Apply Properties| CP[sound_dsound_set_channel_properties 0x2a180]
+    CP -->|Resolve Channels| TR[sound_dsound_channel_try_resolve 0x28780]
+    TR -->|Check Status| IA[dsound_stream_is_active 0x19c5e7]
+```
+
+---
+
+## 2. Function Inventory & Database Updates
+
+The following functions have been identified, renamed, and commented in the active IDA Pro database (`cachebeta.xbe.i64`):
+
+| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
+| :--- | :--- | :--- | :--- |
+| **`0x285A0`** | `sub_285A0` | `sound_dsound_dispose` | Disposes DirectSound objects and cleans up active audio buffers. |
+| **`0x28780`** | `sub_28780` | `sound_dsound_channel_try_resolve` | Searches for inactive actual channels to bind to a virtual channel request. |
+| **`0x28840`** | `sub_28840` | `sound_dsound_log_error` | Outputs detailed DirectSound warning and error HRESULT diagnostic logs. |
+| **`0x28BD0`** | `sub_28BD0` | `sound_dsound_set_listener_properties` | Configures 3D listener positions, velocity vectors, and environmental reverb. |
+| **`0x296D0`** | `sub_296D0` | `sound_dsound_stream_update_i3dl2` | Submits I3DL2 (Interactive 3D Audio Level 2) room reflection parameters to hardware. |
+| **`0x297B0`** | `sub_297B0` | `sound_dsound_stream_set_properties` | DirectSound stream updater processing pitch, volume, and cone attenuation properties. |
+| **`0x29A40`** | `sub_29A40` | `sound_dsound_stream_update_3d` | Calculates and applies updated 3D coordinate matrices to active streams. |
+| **`0x29CB0`** | `sub_29CB0` | `sound_dsound_stream_create` | Allocates and boots hardware voice streams using `IDirectSound_CreateSoundStream`. |
+| **`0x29F10`** | `sub_29F10` | `sound_dsound_initialize` | Initializer creating the DirectSound COM instance, configuring distance factors, and loading DSP image. |
+| **`0x2A180`** | `sub_2A180` | `sound_dsound_set_channel_properties` | Translates sound manager channel index into a stream property update command. |
+| **`0x19C5E7`** | `sub_19C5E7` | `dsound_stream_is_active` | Direct kernel memory reader verifying stream status bits against mask `0x10000002`. |
+
+---
+
+## 3. Subsystem Insights
+
+### DSP Image Downloading (`0x29F10`)
+Unlike standard Win32 PC platforms, Xbox uses a specialized NV2A hardware audio processor (MCPX) requiring custom DSP microcode images:
+* `sound_dsound_initialize` uses the Xbox-only API `IDirectSound_DownloadEffectsImage` to download a compiled DSP image payload (`unk_1DCA38`, size `14940` bytes) directly onto the hardware.
+* This DSP image configures the hardware mix bins for Dolby Digital, HRTF spatialization filters, and I3DL2 environment parameters.
+
+### I3DL2 Reverb Integration (`0x28BD0` & `0x296D0`)
+The engine translates positional coordinates and material types into environmental reverb settings:
+* Dynamic changes in rooms/ BSP geometry adjust room, reflection, and decay properties.
+* The settings are formatted into the DirectSound structure and submitted via the Xbox COM method `IDirectSound_SetI3DL2Listener` (for the overall listener context) and `IDirectSoundStream_SetI3DL2Source` (for individual audio sources).
+
+### Kernel-Level Stream Status Checking (`0x19C5E7`)
+To check if a voice/stream is actively playing without blocking CPU execution, `dsound_stream_is_active` queries the Xbox audio processor's hardware channel registers:
+* Instead of using high-level query APIs, it reads the status flags from the stream's memory structure offset `+36` and tests the kernel status bit mask `0x10000002`.
+* Non-zero indicates the hardware voice is still processing samples, preventing premature channel eviction.


### PR DESCRIPTION
# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes

This document captures the reverse engineering findings, mapped functions, database updates, and subsystem details discovered during the survey of the Halo: Combat Evolved Xbox Cache Beta binary (`cachebeta.xbe`).

---

## 1. Mapped Execution Path

We successfully traced the game's startup and initialization sequence from the Windows/Xbox loader to the main game loop:

```mermaid
graph TD
    A[mainCRTStartup 0x15cc9] -->|CreateThread| B[mainXapiStartup 0x15c5a]
    B -->|Call __cdecl| C[main_entry 0x56960]
    C -->|D3D probe| D[rasterizer_preinitialize 0x7f140]
    C -->|Alloc pools| E[physical_memory_allocate 0x32e40]
    C -->|Init subsystems| F[shell_initialize 0x56a20]
    F -->|RNG & Geosphere| G[random_math_initialize 0xb5460]
    F -->|Alloc lookup tables| H[periodic_functions_initialize 0x174350]
    F -->|Direct3D & shaders| I[rasterizer_device_initialize 0x625b0]
    F -->|Input init| J[input_initialize 0xe3be0]
    F -->|Sound manager| K[sound_manager_initialize 0x267a0]
    C -->|Enter loop| L[main_loop 0xbd420]
    C -->|Shutdown/Cleanup| M[shell_dispose 0x569b0]
```

---

## 2. Function Inventory & Database Updates

The following functions have been identified and renamed in the active IDA Pro database (`cachebeta.xbe.i64`):

| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
| :--- | :--- | :--- | :--- |
| **`0x15cc9`** | `mainCRTStartup` | *Unchanged* | CRT Entry point; initializes TLS index, spawns main Xapi thread. |
| **`0x15c5a`** | `mainXapiStartup` | *Unchanged* | Process & thread initialization, runtime initialization (`cinit`/`rtinit`), enters main game flow. |
| **`0x56960`** | `sub_56960` | `main_entry` | Game main entry point. Coordinates pre-initialization, subsystem boot, and loop. |
| **`0x7f140`** | `sub_7F140` | `rasterizer_preinitialize` | Creates temporary Direct3D 8 HAL device (640x480) to query hardware capabilities. |
| **`0x32e40`** | `sub_32E40` | `physical_memory_allocate` | Allocates the primary contiguous memory blocks via `MmAllocateContiguousMemoryEx`. |
| **`0x56a20`** | `sub_56A20` | `shell_initialize` | System initialization sequence (RNG, periodic tables, D3D, Input, Audio). |
| **`0xbd420`** | `sub_BD420` | `main_loop` | Main game loop running ticks, level loads, game state sync, and frame rendering. |
| **`0x569b0`** | `sub_569B0` | `shell_dispose` | Disposes tags, audio, input, and memory resources on exit. |
| **`0xb5460`** | `sub_B5460` | `random_math_initialize` | Sets random seed using entropy sources and triggers geosphere generation. |
| **`0xb8840`** | `sub_B8840` | `random_direction_geosphere_generate` | Generates geodesic dome/sphere coordinates dynamically (different from retail PC). |
| **`0x174350`** | `sub_174350` | `periodic_functions_initialize` | Allocates and fills periodic & transition tables. |
| **`0x174090`** | `sub_174090` | `periodic_function_generate` | Generates 12 specific periodic lookup table patterns. |
| **`0x173c10`** | `sub_173C10` | `transition_function_generate` | Generates 6 specific transition lookup table patterns. |

---

## 3. Subsystem Insights

### Dynamic Geosphere Generation (`0xb8840`)
In the PC retail version of Halo, the unit geosphere vectors used to query random direction angles are loaded from a compiled game tag block (`random_direction_geosphere` tag type `0x10`).
In the Xbox Cache Beta build, we discovered that **`random_direction_geosphere_generate`** builds this mesh procedurally on boot:
* It allocates a vertex buffer for `8 * a1 * a1` elements (`a1 = 16` -> 2048 elements).
* It loops through subdivisions using a userpurge helper (`sub_B8680`) and stores the resulting coordinate floats in a global pointer.
* This dynamic generation completely removes the dependency on the pre-built geosphere tag at startup.

### Periodic & Transition Tables (`0x174350`)
The animation, particle, and FX systems rely on pre-computed waves and ramps:
* **Periodic Tables:** Allocates 12 lookup buffers of `0x400` bytes (total 1024 float/byte entries each) for shapes like cosine, triangle waves, stutter harmonics, and Gaussian curves.
* **Transition Tables:** Allocates 6 lookup buffers of `0x400` bytes mapping transition functions.

---

## 4. Next Tasks / Open Areas
- [ ] Map the network state synchronization packet handlers under `main_loop`.
- [ ] Decompile the Direct3D device creation (`sub_7FA10`) render state details.
- [ ] Match structure block / tag parsing logic inside the cache loader.

# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 2)

This document captures the second phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the network message loops, asynchronous file system I/O, and Xbox-specific NV2A Direct3D render states.

---

## 1. Mapped Execution Path

The diagram below details the execution path of the network tick loop and background asynchronous I/O threads:

```mermaid
graph TD
    ML[main_loop 0xbd420] -->|If Client| CSF[network_game_client_start_frame 0x9eda0]
    ML -->|If Server| SSF[network_game_server_start_frame 0x9d7b0]
    ML -->|Frame End| CEF[network_game_client_end_frame 0x9eae0]
    
    CSF -->|Dispatch State 3| NCM[network_client_process_message 0x17e710]
    NCM -->|Switch Type| MSG[16 Server-to-Client Message Handlers]
    SSF -->|New Connection| SC[sub_9C780]
    
    subgraph Async IO Threads
        T1[map_cache_io_worker_thread_1 0x33af0] -->|De-queue & Read| AR[XapiReadFileAsync 0x153b3]
        T2[map_cache_decompression_worker_thread_2 0x34cf0] -->|Decompress| DC[Cache Sectors]
    end
```

---

## 2. Function Inventory & Database Updates

The following functions have been identified, renamed, and commented in the active IDA Pro database (`cachebeta.xbe.i64`):

| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
| :--- | :--- | :--- | :--- |
| **`0x9eda0`** | `sub_9EDA0` | `network_game_client_start_frame` | Client start frame; manages connection state updates and processes packets. |
| **`0x9d7b0`** | `sub_9D7B0` | `network_game_server_start_frame` | Server start frame; monitors link status and accepts incoming client joins. |
| **`0x9eae0`** | `sub_9EAE0` | `network_game_client_end_frame` | Client end frame; handles packet finalization and transmit queues. |
| **`0x17e710`** | `sub_17E710` | `network_client_process_message` | Client-side network message dispatcher; parses packet headers. |
| **`0x17e200`** | `sub_17E200` | `handle_message_server_game_advertise` | Client handler for incoming server advertise messages (Type 2). |
| **`0x17e1a0`** | `sub_17E1A0` | `handle_message_server_pong` | Client handler for ping response messages (Type 3). |
| **`0x17e0f0`** | `sub_17E0F0` | `handle_message_server_machine_accepted` | Client handler for join machine accepted messages (Type 4). |
| **`0x17e040`** | `sub_17E040` | `handle_message_server_machine_rejected` | Client handler for join machine rejected messages (Type 5). |
| **`0x17e4e0`** | `sub_17E4E0` | `handle_message_server_game_settings_update` | Client handler for settings synchronization messages (Type 6). |
| **`0x17dfa0`** | `sub_17DFA0` | `handle_message_server_pregame_countdown` | Client handler for pregame start countdown status (Type 7). |
| **`0x17e5b0`** | `sub_17E5B0` | `handle_message_server_begin_game` | Client handler for server starting gameplay transition (Type 8). |
| **`0x17ddd0`** | `sub_17DDD0` | `handle_message_server_graceful_game_exit_pregame` | Client handler for pregame graceful disconnect (Type 9). |
| **`0x17df10`** | `sub_17DF10` | `handle_message_server_pregame_keep_alive` | Client handler for pregame keepalive ping (Type 10). |
| **`0x17de80`** | `sub_17DE80` | `handle_message_server_postgame_keep_alive` | Client handler for postgame keepalive ping (Type 11). |
| **`0x17e410`** | `sub_17E410` | `handle_message_server_game_update` | Client handler for in-game state sync packet payload (Type 20). |
| **`0x17e350`** | `sub_17E350` | `handle_message_server_add_player_ingame` | Client handler for dynamic player join announcements (Type 21). |
| **`0x17e290`** | `sub_17E290` | `handle_message_server_remove_player_ingame` | Client handler for dynamic player quit announcements (Type 22). |
| **`0x17dd40`** | `sub_17DD40` | `handle_message_server_game_over` | Client handler for match game-over announcements (Type 23). |
| **`0x17e660`** | `sub_17E660` | `handle_message_server_switch_to_pregame` | Client handler for postgame transition back to lobby (Type 30). |
| **`0x17dc80`** | `sub_17DC80` | `handle_message_server_graceful_game_exit_postgame` | Client handler for postgame lobby exit/cleanup status (Type 31). |
| **`0x14640`** | `sub_14640` | `XapiCreateFile` | standard wrapper translating parameters to NT Native `NtCreateFile`. |
| **`0x15455`** | `sub_15455` | `XapiGetFileSize` | Wrapper mapping standard Win32 file size query logic. |
| **`0x15375`** | `sub_15375` | `XapiGetFileSizeEx` | Calls `NtQueryInformationFile` for standard size attributes. |
| **`0x150a4`** | `sub_150A4` | `XapiSetFilePointer` | Calls `NtSetInformationFile` for current file pointer update. |
| **`0x15020`** | `sub_15020` | `XapiSetEndOfFile` | Calls `NtSetInformationFile` to truncate/adjust file size. |
| **`0x153b3`** | `sub_153B3` | `XapiReadFileAsync` | Asynchronous file read callback wrapper calling `NtReadFile`. |
| **`0x15404`** | `sub_15404` | `XapiWriteFileAsync` | Asynchronous file write callback wrapper calling `NtWriteFile`. |
| **`0x331d0`** | `sub_331D0` | `XapiExecuteAsyncIo` | Standard async I/O loop worker coordinating pending APC queues. |
| **`0x33af0`** | `StartAddress` | `map_cache_io_worker_thread_1` | Worker thread prioritizing and submitting file read requests. |
| **`0x34cf0`** | `sub_34CF0` | `map_cache_decompression_worker_thread_2` | Worker thread decompressing streamed map sectors in background. |
| **`0x625b0`** | `sub_625B0` | `rasterizer_device_initialize` | Sets up memory contexts and starts Direct3D hardware device. |
| **`0x7fa10`** | `sub_7FA10` | `rasterizer_device_initialize_internal` | Allocates textures, sets shader constant mode, and configures GPU render states. |

---

## 3. Subsystem Insights

### Dynamic Geosphere Generation (`0xb8840`)
In the PC retail version of Halo, the unit geosphere vectors used to query random direction angles are loaded from a compiled game tag block (`random_direction_geosphere` tag type `0x10`).
In the Xbox Cache Beta build, we discovered that **`random_direction_geosphere_generate`** builds this mesh procedurally on boot:
* It allocates a vertex buffer for `8 * a1 * a1` elements (`a1 = 16` -> 2048 elements).
* It loops through subdivisions using a userpurge helper (`sub_B8680`) and stores the resulting coordinate floats in a global pointer.
* This dynamic generation completely removes the dependency on the pre-built geosphere tag at startup.

### Periodic & Transition Tables (`0x174350`)
The animation, particle, and FX systems rely on pre-computed waves and ramps:
* **Periodic Tables:** Allocates 12 lookup buffers of `0x400` bytes (total 1024 float/byte entries each) for shapes like cosine, triangle waves, stutter harmonics, and Gaussian curves.
* **Transition Tables:** Allocates 6 lookup buffers of `0x400` bytes mapping transition functions.

---

## 4. Xbox NV2A D3D Render States

During D3D device setup in **`rasterizer_device_initialize_internal` (`0x7fa10`)**, we mapped the following Xbox-specific registers and render states:

* **Alpha Blend Enable (`0x40304` / `820`):** Set to 1 to enable alpha blending.
* **Alpha Blend Source/Destination (`0x40344` / `836`):** Standard blending multipliers.
* **Alpha Blend Op (`0x40348` / `840`):** Set to `0x8006` (`D3DBLENDOP_ADD`).
* **Depth/Z-Comparison Function (`0x40354` / `852`):** Set to `515` (`0x203` -> `D3DCMP_LESSEQUAL`).
* **Logical Op (`0x4035c` / `860`):** Direct GPU logical raster operations.
* **Soft Display & Flicker Filters:** Xbox TV output encoders configured to use flicker filtering.

# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 3)

This document captures the third phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the Object Table Manager subsystem, Xbox player profiles (async disk I/O, signing), and multiplayer biped configuration paths.

---

## 1. Mapped Execution Paths

### Object Update & Garbage Collection Flow
The diagram below details the interaction flow between player tick updates, relevance determination, and the garbage collection of dead/unreachable game entities:

```mermaid
graph TD
    ML[main_loop 0xbd420] -->|Every Tick| OU[objects_update 0x145170]
    ML -->|Every Tick| GC[objects_garbage_collect_tick 0x144B00]
    
    GC -->|Actor Update Evaluator| AU[actor_update_evaluator 0x144290]
    GC -->|If Out of Bounds / Dead| OD[object_delete_internal 0x140BC0]
    
    OU -->|Player Relevance Loop| RL[objects_update_relevance_loop 0x1451B0]
    RL -->|Iterate Players| PI[player_iterator 0x13AA00]
    RL -->|Update Relevance| UR[object_update_relevance 0x144CF0]
    UR -->|Relevance Helper| IR[object_is_player_relevant 0x145140]
```

### Profile Saving & Biped Selection Flow
The diagram below illustrates how player character model updates are written to the local filesystem (`z:\last_solo.txt`) and asynchronously signed and saved to the Xbox hard disk:

```mermaid
graph TD
    ML[main_loop 0xbd420] -->|Menu Loop| MM[main_menu_update 0xbd2d0]
    MM -->|Startup Load| PL[player_load_last_solo_biped_model 0xbc020]
    PL -->|Read String| PF[player_biped_model_from_string 0xbbb90]
    PL -->|Copy Cache| PN[player_set_biped_model_name 0xbbdc0]
    
    MM -->|Apply Settings| PS[player_save_last_solo_biped_model 0xbbd70]
    PS -->|Write Cache| PF
    
    MM -->|Queue Profile Save| PA[player_profile_save_async 0x30ce0]
    PA -->|Spawn Thread| PW[player_profile_save_thread_worker 0x30bc0]
    PW -->|Xbox Signature| XS[XCalculateSignatureBegin API]
```

---

## 2. Function Inventory & Database Updates

The following functions have been identified, renamed, and commented in the active IDA Pro database (`cachebeta.xbe.i64`):

| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
| :--- | :--- | :--- | :--- |
| **`0x30BC0`** | `sub_30BC0` | `player_profile_save_thread_worker` | Async thread worker that calculates savegame signatures and writes profiles to disk. |
| **`0x30CE0`** | `sub_30CE0` | `player_profile_save_async` | Initiates asynchronous player profile saves using Xbox worker threads. |
| **`0x13AA00`** | `sub_13AA00` | `player_iterator` | Iterator helper that traverses active player indices inside player tables. |
| **`0x140BC0`** | `sub_140BC0` | `object_delete_internal` | Main function that tears down unit references, cleans attachments, and deletes objects. |
| **`0x143C00`** | `sub_143C00` | `object_new` | Instantiates new objects and registers headers inside the global data tables. |
| **`0x144290`** | `sub_144290` | `actor_update_evaluator` | Handles per-tick evaluations of player-to-actor visibility and updates. |
| **`0x144B00`** | `sub_144B00` | `objects_garbage_collect_tick` | Ticks periodic dynamic entity cleanup loops and monitors overall memory pressure. |
| **`0x144CF0`** | `sub_144CF0` | `object_update_relevance` | Inner relevance routine evaluating distances, visibility, and state of players. |
| **`0x145140`** | `sub_145140` | `object_is_player_relevant` | Checks if a given player is near or relevant (e.g. within 5.0 units distance). |
| **`0x1451B0`** | `sub_1451B0` | `objects_update_relevance_loop` | Outer relevance loop checking player relationship tables for updates. |
| **`0x1453A0`** | `sub_1453A0` | `objects_update_visibility_loop` | Checks player-to-player visibility changes and updates player relationship indices. |
| **`0xBBB90`** | `sub_BBB90` | `player_biped_model_from_string` | Parses string representations of multiplayer characters (e.g. `"a10"`, `"b30"`) to index `0-9`. |
| **`0xBBD70`** | `sub_BBD70` | `player_save_last_solo_biped_model` | Saves the chosen player model name string to the Xbox cache file `z:\last_solo.txt`. |
| **`0xBBDC0`** | `sub_BBDC0` | `player_set_biped_model_name` | Copies the chosen biped model string name to the global memory buffer. |
| **`0xBC020`** | `sub_BC020` | `player_load_last_solo_biped_model` | Reads `z:\last_solo.txt` at boot to restore the last configured character model. |
| **`0xBD2D0`** | `sub_BD2D0` | `main_menu_update` | Main loop sub-helper executing menu screens, title music, and biped changes. |

---

## 3. Subsystem Insights

### Dynamic Entity Garbage Collection (`0x144B00`)
The game engine maintains system stability by performing a periodic garbage collection sweep of objects. Under `objects_garbage_collect_tick`:
* It iterates through active actors/units using `player_iterator` structures.
* It checks if entities are dead or marked for deletion (using unit shield/body vitality checks or out-of-bounds map checks).
* If an entity is marked for deletion or fails active presence checks, it calls `object_delete_internal` to clean up parent/child attachments and release its slots from the `player_data` array.

### Player Relevance & Update Rates (`0x1451B0` & `0x144CF0`)
The engine dynamically adjusts update rates based on spatial relationship and PVS (Potentially Visible Set) state:
* Local players and entities in the same PVS sector are marked as high relevance and update every tick.
* Remote/distant players are checked via `object_is_player_relevant` against a distance threshold (e.g., `5.0` units).
* If a remote player is too far away or outside the active PVS, updates are throttled to save bandwidth and FPU computation time.

### Xbox Biped Cache & Profiles (`0xBBB90` & `0xBC020`)
Xbox Halo manages local client customization profiles differently from standard PC builds:
* **Model Choices**: The biped/model indices are mapped from strings: `"a10"`, `"a30"`, `"a50"`, `"b30"`, `"b40"`, `"c10"`, `"c20"`, `"c40"`, `"d20"`, `"d40"`.
* **FS Cache**: It saves the last chosen biped model choice directly to `z:\last_solo.txt`. The `Z:` drive represents the Xbox DVD cache utility partition, allowing fast startup configuration reads without mounting large content paths.
* **Async Profiles**: When saving player settings, the engine executes `player_profile_save_async` to spawn a worker thread (`player_profile_save_thread_worker`). This worker thread uses the Xbox XDK `XCalculateSignatureBegin` API family to append tamper-proof SHA1 signatures to savegames before flushing them to the hard disk.

# Halo: Combat Evolved (Xbox Beta) Decompilation Survey Notes (Part 4)

This document captures the fourth phase of reverse engineering findings on the Halo: Combat Evolved Xbox Cache Beta (`cachebeta.xbe`). We focus on the DirectSound audio engine layer, Xbox-specific hardware voices, environmental reverb (I3DL2), and kernel-level stream status tracking.

---

## 1. Mapped Execution Path

The diagram below details the DirectSound initialization, stream configuration, and channel resolution pipelines:

```mermaid
graph TD
    SM[sound_manager_initialize 0x267a0] -->|Driver Initialize| SI[sound_dsound_initialize 0x29f10]
    SI -->|Listener Setup| SL[sound_dsound_set_listener_properties 0x28bd0]
    SI -->|Create streams| SC[sound_dsound_stream_create 0x29cb0]
    
    SC -->|Configure channels| SP[sound_dsound_stream_set_properties 0x297b0]
    SP -->|Update 3D| S3[sound_dsound_stream_update_3d 0x29a40]
    SP -->|Update I3DL2 Reverb| SR[sound_dsound_stream_update_i3dl2 0x296d0]
    
    PLAY[Sound Playback Ticks] -->|Apply Properties| CP[sound_dsound_set_channel_properties 0x2a180]
    CP -->|Resolve Channels| TR[sound_dsound_channel_try_resolve 0x28780]
    TR -->|Check Status| IA[dsound_stream_is_active 0x19c5e7]
```

---

## 2. Function Inventory & Database Updates

The following functions have been identified, renamed, and commented in the active IDA Pro database (`cachebeta.xbe.i64`):

| Address | Original Symbol | Mapped/Renamed Symbol | Subsystem / Description |
| :--- | :--- | :--- | :--- |
| **`0x285A0`** | `sub_285A0` | `sound_dsound_dispose` | Disposes DirectSound objects and cleans up active audio buffers. |
| **`0x28780`** | `sub_28780` | `sound_dsound_channel_try_resolve` | Searches for inactive actual channels to bind to a virtual channel request. |
| **`0x28840`** | `sub_28840` | `sound_dsound_log_error` | Outputs detailed DirectSound warning and error HRESULT diagnostic logs. |
| **`0x28BD0`** | `sub_28BD0` | `sound_dsound_set_listener_properties` | Configures 3D listener positions, velocity vectors, and environmental reverb. |
| **`0x296D0`** | `sub_296D0` | `sound_dsound_stream_update_i3dl2` | Submits I3DL2 (Interactive 3D Audio Level 2) room reflection parameters to hardware. |
| **`0x297B0`** | `sub_297B0` | `sound_dsound_stream_set_properties` | DirectSound stream updater processing pitch, volume, and cone attenuation properties. |
| **`0x29A40`** | `sub_29A40` | `sound_dsound_stream_update_3d` | Calculates and applies updated 3D coordinate matrices to active streams. |
| **`0x29CB0`** | `sub_29CB0` | `sound_dsound_stream_create` | Allocates and boots hardware voice streams using `IDirectSound_CreateSoundStream`. |
| **`0x29F10`** | `sub_29F10` | `sound_dsound_initialize` | Initializer creating the DirectSound COM instance, configuring distance factors, and loading DSP image. |
| **`0x2A180`** | `sub_2A180` | `sound_dsound_set_channel_properties` | Translates sound manager channel index into a stream property update command. |
| **`0x19C5E7`** | `sub_19C5E7` | `dsound_stream_is_active` | Direct kernel memory reader verifying stream status bits against mask `0x10000002`. |

---

## 3. Subsystem Insights

### DSP Image Downloading (`0x29F10`)
Unlike standard Win32 PC platforms, Xbox uses a specialized NV2A hardware audio processor (MCPX) requiring custom DSP microcode images:
* `sound_dsound_initialize` uses the Xbox-only API `IDirectSound_DownloadEffectsImage` to download a compiled DSP image payload (`unk_1DCA38`, size `14940` bytes) directly onto the hardware.
* This DSP image configures the hardware mix bins for Dolby Digital, HRTF spatialization filters, and I3DL2 environment parameters.

### I3DL2 Reverb Integration (`0x28BD0` & `0x296D0`)
The engine translates positional coordinates and material types into environmental reverb settings:
* Dynamic changes in rooms/ BSP geometry adjust room, reflection, and decay properties.
* The settings are formatted into the DirectSound structure and submitted via the Xbox COM method `IDirectSound_SetI3DL2Listener` (for the overall listener context) and `IDirectSoundStream_SetI3DL2Source` (for individual audio sources).

### Kernel-Level Stream Status Checking (`0x19C5E7`)
To check if a voice/stream is actively playing without blocking CPU execution, `dsound_stream_is_active` queries the Xbox audio processor's hardware channel registers:
* Instead of using high-level query APIs, it reads the status flags from the stream's memory structure offset `+36` and tests the kernel status bit mask `0x10000002`.
* Non-zero indicates the hardware voice is still processing samples, preventing premature channel eviction.
